### PR TITLE
import Javalin as another ws-server

### DIFF
--- a/projector-server/src/main/kotlin/org/jetbrains/projector/server/ProjectorServer.kt
+++ b/projector-server/src/main/kotlin/org/jetbrains/projector/server/ProjectorServer.kt
@@ -699,8 +699,14 @@ class ProjectorServer private constructor(
     updateThread = createUpdateThread()
     caretInfoUpdater.start()
 
-    WebsocketServer.createTransportBuilders().forEach {
-      addTransport(it.attachDefaultServerEventHandlers(clientEventHandler).build())
+    when (ENABLE_JETTY_WS_SERVER) {
+      true -> WebsocketServer.createJTransportBuilders().forEach {
+        addTransport(it.attachDefaultServerEventHandlers(clientEventHandler).build())
+
+      }
+      false -> WebsocketServer.createTransportBuilders().forEach {
+        addTransport(it.attachDefaultServerEventHandlers(clientEventHandler).build())
+      }
     }
   }
 
@@ -935,5 +941,8 @@ class ProjectorServer private constructor(
     fun isLocalAddress(address: InetAddress) = address in LOCAL_ADDRESSES
 
     private val isMac get() = System.getProperty("os.name").startsWith("Mac OS")
+
+    private const val ENABLE_JETTY_WS_SERVER_CONF = "ORG_JETBRAINS_PROJECTOR_SERVER_ENABLE_JETTY_WS"
+    val ENABLE_JETTY_WS_SERVER = getOption(ENABLE_JETTY_WS_SERVER_CONF, "true").toBoolean()
   }
 }

--- a/projector-server/src/main/kotlin/org/jetbrains/projector/server/websocket/WebsocketServer.kt
+++ b/projector-server/src/main/kotlin/org/jetbrains/projector/server/websocket/WebsocketServer.kt
@@ -27,6 +27,8 @@ import org.jetbrains.projector.common.protocol.data.ImageData
 import org.jetbrains.projector.common.protocol.data.ImageId
 import org.jetbrains.projector.common.protocol.toClient.MainWindow
 import org.jetbrains.projector.server.ProjectorServer
+import org.jetbrains.projector.server.core.jwebsocket.JHttpWsServerBuilder
+import org.jetbrains.projector.server.core.jwebsocket.JWsTransportBuilder
 import org.jetbrains.projector.server.core.util.getOption
 import org.jetbrains.projector.server.core.websocket.HttpWsClientBuilder
 import org.jetbrains.projector.server.core.websocket.HttpWsServerBuilder
@@ -70,6 +72,35 @@ object WebsocketServer {
       }
 
       builders.add(serverBuilder)
+    }
+    return builders
+  }
+
+  internal fun createJTransportBuilders(): List<JWsTransportBuilder> {
+    val builders = arrayListOf<JWsTransportBuilder>()
+
+    // Not implement relay using !!
+
+    if (getOption(ENABLE_WS_SERVER_PROPERTY, "true").toBoolean()) {
+      val host = ProjectorServer.getEnvHost()
+      val port = ProjectorServer.getEnvPort()
+      logger.info { "${ProjectorServer::class.simpleName} is starting on host $host and port $port" }
+
+      val jserverBuilder = JHttpWsServerBuilder(host, port)
+
+      jserverBuilder.getMainWindows = {
+        ProjectorServer.getMainWindows().map {
+          MainWindow(
+            title = it.title,
+            pngBase64Icon = it.icons
+              ?.firstOrNull()
+              ?.let { imageId -> ProjectorImageCacher.getImage(imageId as ImageId) as? ImageData.PngBase64 }
+              ?.pngBase64,
+          )
+        }
+      }
+
+      builders.add(jserverBuilder)
     }
     return builders
   }


### PR DESCRIPTION
You can use -DORG_JETBRAINS_PROJECTOR_SERVER_ENABLE_JETTY_WS=true at Projector startup args to enable Javalin as websocket server  

Client PR: https://github.com/zhipengzuo/projector-client/pull/5